### PR TITLE
Added cleanRemoteIP function to Fix #16

### DIFF
--- a/bitbucket_hook.go
+++ b/bitbucket_hook.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 )
 
 // See: https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html
@@ -96,8 +97,13 @@ func (b BitbucketHook) handlePush(body []byte, repo *Repo) error {
 	return nil
 }
 
+func cleanRemoteIP(remoteIP string) string {
+	// *httpRequest.RemoteAddr comes in format IP:PORT, remove the port
+	return strings.Split(remoteIP, ":")[0]
+}
+
 func (b BitbucketHook) verifyBitbucketIP(remoteIP string) bool {
-	ipAddress := net.ParseIP(remoteIP)
+	ipAddress := net.ParseIP(cleanRemoteIP(remoteIP))
 	for _, cidr := range bitbucketIPBlocks {
 		_, cidrnet, err := net.ParseCIDR(cidr)
 		if err != nil {


### PR DESCRIPTION
httpRequest.RemoteAddr comes in the format IP:PORT (for example `131.103.20.165:23232`).

Added a method to clean the port from the remote address if it exists, this way `net.ParseIP` receives an IP with the expected format.