### PR TITLE
Add note about quotes around webhook the webhook secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ git git@github.com:user/site {
 }
 ```
 
+You might need quotes `"secret-password"` around your secret if it contains any special characters, or you get an error.
+
 <a name="generic_format"></a>
 Generic webhook payload: `<branch>` is branch name e.g. `master`.
 ```


### PR DESCRIPTION
I had to add quotes around the secret as we talked about on Slack. This is a pull-requests that adds a note about this in the README