### PR TITLE
Add support for verifying GitLab hooks with token

### DIFF
--- a/gitlab_hook.go
+++ b/gitlab_hook.go
@@ -63,7 +63,7 @@ func (g GitlabHook) Handle(w http.ResponseWriter, r *http.Request, repo *Repo) (
 	return http.StatusOK, err
 }
 
-// Check for an optional token in the request. GitLab's webhook tokens are just
+// handleToken checks for an optional token in the request. GitLab's webhook tokens are just
 // simple strings that get sent as a header with the hook request. If one
 // exists, verify that it matches the secret in the Caddy configuration.
 func (g GitlabHook) handleToken(r *http.Request, body []byte, secret string) error {


### PR DESCRIPTION
GitLab has a basic method for securing webhook requests. A user can
specify a token in the repository's settings, and the token will be
included in a header with webhook requests. Verification consists in
asserting server-side that the token in the header is the expected
value.

Closes #46